### PR TITLE
Allow custom start number for highlight

### DIFF
--- a/client/components/editor/editor-markdown.vue
+++ b/client/components/editor/editor-markdown.vue
@@ -258,7 +258,10 @@ const md = new MarkdownIt({
     } else if (['mermaid', 'plantuml'].includes(lang)) {
       return `<pre class="codeblock-${lang}"><code>${_.escape(str)}</code></pre>`
     } else {
-      return `<pre class="line-numbers"><code class="language-${lang}">${_.escape(str)}</code></pre>`
+      // support start at a custom line number
+      const startLineMatches = lang.match(/=(\d+)$/)
+      const startLine = startLineMatches ? startLineMatches[1] : 1
+      return `<pre class="line-numbers" data-start="${startLine}"><code class="language-${lang}">${_.escape(str)}</code></pre>`
     }
   }
 })

--- a/server/modules/rendering/html-codehighlighter/definition.yml
+++ b/server/modules/rendering/html-codehighlighter/definition.yml
@@ -11,5 +11,5 @@ props:
     type: Boolean
     default: false
     title: Allow custom line number start
-    hint: For example, using ```javascript=5 will start the line numbers at 5.
+    hint: For example, using ```javascript=5 will start the line numbering at 5
     order: 1

--- a/server/modules/rendering/html-codehighlighter/definition.yml
+++ b/server/modules/rendering/html-codehighlighter/definition.yml
@@ -6,4 +6,10 @@ icon: mdi-code-braces
 enabledDefault: true
 dependsOn: htmlCore
 step: pre
-props: {}
+props:
+  customStartNumber:
+    type: Boolean
+    default: false
+    title: Allow custom line number start
+    hint: For example, using ```javascript=5 will start the line numbers at 5.
+    order: 1

--- a/server/modules/rendering/html-codehighlighter/renderer.js
+++ b/server/modules/rendering/html-codehighlighter/renderer.js
@@ -9,6 +9,12 @@ module.exports = {
         $(elm).addClass('language-', result.language)
       }
       $(elm).parent().addClass('prismjs line-numbers')
+
+      if (config.customStartNumber) {
+        const startNumberMatches = codeClasses.match(/language-.*=(\d+)/)
+        const startNumber = startNumberMatches ? parseInt(startNumberMatches[1]) : 1
+        $(elm).parent().attr('data-start', startNumber)
+      }
     })
   }
 }


### PR DESCRIPTION

```
    ```javascript=4
     var s = "JavaScript syntax highlighting";
     alert(s);
    ```
```

<img width="550" alt="image" src="https://github.com/VNOI-Admin/wiki/assets/23715841/f3a56b3b-ad6d-4183-9b6a-01610b9ec07c">

<img width="488" alt="image" src="https://github.com/VNOI-Admin/wiki/assets/23715841/ade58e34-4506-4ca4-bb50-5871c165ac5e">
