### PR TITLE
Disable markdown-it-attrs by default to fix math bracket

### DIFF
--- a/client/components/editor/common/katex.js
+++ b/client/components/editor/common/katex.js
@@ -81,14 +81,7 @@ export default {
     if (!silent) {
       token = state.push('katex_inline', 'math', 0)
       token.markup = '$'
-      token.content = state.src
-        // Extract the math part without the $
-        .slice(start, match)
-        // Escape the curly braces since they will be interpreted as
-        // attributes by markdown-it-attrs (the "curly_attributes"
-        // core rule)
-        .replaceAll("{", "{{")
-        .replaceAll("}", "}}")
+      token.content = state.src.slice(start, match)
     }
 
     state.pos = match + 1

--- a/client/components/editor/editor-markdown.vue
+++ b/client/components/editor/editor-markdown.vue
@@ -265,9 +265,10 @@ const md = new MarkdownIt({
     }
   }
 })
-  .use(mdAttrs, {
-    allowedAttributes: ['id', 'class', 'target']
-  })
+  // TODO: some how read the config from backend?
+  // .use(mdAttrs, {
+  //   allowedAttributes: ['id', 'class', 'target']
+  // })
   .use(mdDecorate)
   .use(underline)
   .use(mdEmoji)

--- a/server/modules/rendering/markdown-core/definition.yml
+++ b/server/modules/rendering/markdown-core/definition.yml
@@ -61,3 +61,10 @@ props:
       - Spanish
       - Swedish
     public: true
+  mdAttrs:
+    type: Boolean
+    default: false
+    title: Use markdown-it-attrs
+    hint: Enable the markdown-it-attrs plugin. This could cause conflicts with Latex due to the use of {}
+    order: 7
+    public: true

--- a/server/modules/rendering/markdown-core/renderer.js
+++ b/server/modules/rendering/markdown-core/renderer.js
@@ -40,9 +40,12 @@ module.exports = {
       mkdown.use(underline)
     }
 
-    mkdown.use(mdAttrs, {
-      allowedAttributes: ['id', 'class', 'target']
-    })
+    if (this.config.mdAttrs) {
+      mkdown.use(mdAttrs, {
+        allowedAttributes: ['id', 'class', 'target']
+      })
+    }
+
     mkdown.use(mdDecorate)
 
     for (let child of this.children) {


### PR DESCRIPTION
Currently, the following issue with the bracket in latex:
- Couldn't show `{` because of the replacing requarks#2645. And that PR is not even completed, they solved the FE issue but the BE renderer stayed the same 😵‍💫 
- And this: requarks#1462 

So those issues come from the use of `markdown-it-attrs` and the not-so-greate fix from the PR above. In the use of vnoi wiki, we don't use `markdown-it-attrs` so:
- I ended up removing the use of `markdown-it-attrs` in the editor. For the backend, it can be config in the admin-ui, rendering section!


Before:
<img width="248" alt="image" src="https://github.com/VNOI-Admin/wiki/assets/23715841/b6cd4737-b046-438c-bafd-fee6428aa96c">
<img width="171" alt="image" src="https://github.com/VNOI-Admin/wiki/assets/23715841/93813ee4-0a92-45d6-abf5-58dd8364676a">

After:
<img width="85" alt="image" src="https://github.com/VNOI-Admin/wiki/assets/23715841/2e2d211f-9106-4aa1-9f2a-608a12ad0fac">
