### PR TITLE
latex: remove non-whitespace conditions, add latex matcher helper

### DIFF
--- a/server/helpers/latex-matcher.js
+++ b/server/helpers/latex-matcher.js
@@ -1,45 +1,40 @@
-// Test if potential opening or closing delimieter
-// Assumes that there is a "$" at state.src[pos]
-function isValidDelim (state, pos) {
-  // In VNOI Wiki, we don't have non-whitespace conditions for opening and closing,
-  // and we don't check that closing delimeter isn't followed by a number.
-  // So we just return true.
-  return {
-    canOpen: true,
-    canClose: true
-  }
-  // let prevChar
-  // let nextChar
-  // let max = state.posMax
-  // let canOpen = true
-  // let canClose = true
+module.exports = {
+  // Test if potential opening or closing delimieter
+  // Assumes that there is a "$" at state.src[pos]
+  isValidDelim (state, pos) {
+    // In VNOI Wiki, we don't have non-whitespace conditions for opening and closing,
+    // and we don't check that closing delimeter isn't followed by a number.
+    // So we just return true.
+    return {
+      canOpen: true,
+      canClose: true
+    }
+    // let prevChar
+    // let nextChar
+    // let max = state.posMax
+    // let canOpen = true
+    // let canClose = true
 
-  // prevChar = pos > 0 ? state.src.charCodeAt(pos - 1) : -1
-  // nextChar = pos + 1 <= max ? state.src.charCodeAt(pos + 1) : -1
+    // prevChar = pos > 0 ? state.src.charCodeAt(pos - 1) : -1
+    // nextChar = pos + 1 <= max ? state.src.charCodeAt(pos + 1) : -1
 
-  // // Check non-whitespace conditions for opening and closing, and
-  // // check that closing delimeter isn't followed by a number
-  // if (prevChar === 0x20/* " " */ || prevChar === 0x09/* \t */ ||
-  //         (nextChar >= 0x30/* "0" */ && nextChar <= 0x39/* "9" */)) {
-  //   canClose = false
-  // }
-  // if (nextChar === 0x20/* " " */ || nextChar === 0x09/* \t */) {
-  //   canOpen = false
-  // }
+    // // Check non-whitespace conditions for opening and closing, and
+    // // check that closing delimeter isn't followed by a number
+    // if (prevChar === 0x20/* " " */ || prevChar === 0x09/* \t */ ||
+    //         (nextChar >= 0x30/* "0" */ && nextChar <= 0x39/* "9" */)) {
+    //   canClose = false
+    // }
+    // if (nextChar === 0x20/* " " */ || nextChar === 0x09/* \t */) {
+    //   canOpen = false
+    // }
+  },
 
-  // return {
-  //   canOpen: canOpen,
-  //   canClose: canClose
-  // }
-}
-
-export default {
-  katexInline (state, silent) {
+  latexInline (tokenName, state, silent) {
     let start, match, token, res, pos
 
     if (state.src[state.pos] !== '$') { return false }
 
-    res = isValidDelim(state, state.pos)
+    res = this.isValidDelim(state, state.pos)
     if (!res.canOpen) {
       if (!silent) { state.pending += '$' }
       state.pos += 1
@@ -78,7 +73,7 @@ export default {
     }
 
     // Check for valid closing delimiter
-    res = isValidDelim(state, match)
+    res = this.isValidDelim(state, match)
     if (!res.canClose) {
       if (!silent) { state.pending += '$' }
       state.pos = start
@@ -86,7 +81,7 @@ export default {
     }
 
     if (!silent) {
-      token = state.push('katex_inline', 'math', 0)
+      token = state.push(tokenName, 'math', 0)
       token.markup = '$'
       token.content = state.src.slice(start, match)
     }
@@ -95,7 +90,7 @@ export default {
     return true
   },
 
-  katexBlock (state, start, end, silent) {
+  latexBlock (tokenName, state, start, end, silent) {
     let firstLine; let lastLine; let next; let lastPos; let found = false; let token
     let pos = state.bMarks[start] + state.tShift[start]
     let max = state.eMarks[start]
@@ -135,7 +130,7 @@ export default {
 
     state.line = next + 1
 
-    token = state.push('katex_block', 'math', 0)
+    token = state.push(tokenName, 'math', 0)
     token.block = true
     token.content = (firstLine && firstLine.trim() ? firstLine + '\n' : '') +
     state.getLines(start + 1, next, state.tShift[start], true) +
@@ -144,4 +139,5 @@ export default {
     token.markup = '$$'
     return true
   }
+
 }

--- a/server/modules/rendering/markdown-katex/renderer.js
+++ b/server/modules/rendering/markdown-katex/renderer.js
@@ -1,5 +1,6 @@
 const katex = require('katex')
 const chemParse = require('./mhchem')
+const latexMatcher = require('../../../helpers/latex-matcher')
 
 /* global WIKI */
 
@@ -33,7 +34,7 @@ module.exports = {
   init (mdinst, conf) {
     const macros = {}
     if (conf.useInline) {
-      mdinst.inline.ruler.after('escape', 'katex_inline', katexInline)
+      mdinst.inline.ruler.after('escape', 'katex_inline', (...args) => latexMatcher.latexInline('katex_inline', ...args))
       mdinst.renderer.rules.katex_inline = (tokens, idx) => {
         try {
           return katex.renderToString(tokens[idx].content, {
@@ -48,7 +49,7 @@ module.exports = {
       }
     }
     if (conf.useBlocks) {
-      mdinst.block.ruler.after('blockquote', 'katex_block', katexBlock, {
+      mdinst.block.ruler.after('blockquote', 'katex_block', (...args) => latexMatcher.latexBlock('katex_block', ...args), {
         alt: [ 'paragraph', 'reference', 'blockquote', 'list' ]
       })
       mdinst.renderer.rules.katex_block = (tokens, idx) => {
@@ -65,143 +66,4 @@ module.exports = {
       }
     }
   }
-}
-
-// Test if potential opening or closing delimieter
-// Assumes that there is a "$" at state.src[pos]
-function isValidDelim (state, pos) {
-  let prevChar
-  let nextChar
-  let max = state.posMax
-  let canOpen = true
-  let canClose = true
-
-  prevChar = pos > 0 ? state.src.charCodeAt(pos - 1) : -1
-  nextChar = pos + 1 <= max ? state.src.charCodeAt(pos + 1) : -1
-
-  // Check non-whitespace conditions for opening and closing, and
-  // check that closing delimeter isn't followed by a number
-  if (prevChar === 0x20/* " " */ || prevChar === 0x09/* \t */ ||
-          (nextChar >= 0x30/* "0" */ && nextChar <= 0x39/* "9" */)) {
-    canClose = false
-  }
-  if (nextChar === 0x20/* " " */ || nextChar === 0x09/* \t */) {
-    canOpen = false
-  }
-
-  return {
-    canOpen: canOpen,
-    canClose: canClose
-  }
-}
-
-function katexInline (state, silent) {
-  let start, match, token, res, pos
-
-  if (state.src[state.pos] !== '$') { return false }
-
-  res = isValidDelim(state, state.pos)
-  if (!res.canOpen) {
-    if (!silent) { state.pending += '$' }
-    state.pos += 1
-    return true
-  }
-
-  // First check for and bypass all properly escaped delimieters
-  // This loop will assume that the first leading backtick can not
-  // be the first character in state.src, which is known since
-  // we have found an opening delimieter already.
-  start = state.pos + 1
-  match = start
-  while ((match = state.src.indexOf('$', match)) !== -1) {
-    // Found potential $, look for escapes, pos will point to
-    // first non escape when complete
-    pos = match - 1
-    while (state.src[pos] === '\\') { pos -= 1 }
-
-    // Even number of escapes, potential closing delimiter found
-    if (((match - pos) % 2) === 1) { break }
-    match += 1
-  }
-
-  // No closing delimter found.  Consume $ and continue.
-  if (match === -1) {
-    if (!silent) { state.pending += '$' }
-    state.pos = start
-    return true
-  }
-
-  // Check if we have empty content, ie: $$.  Do not parse.
-  if (match - start === 0) {
-    if (!silent) { state.pending += '$$' }
-    state.pos = start + 1
-    return true
-  }
-
-  // Check for valid closing delimiter
-  res = isValidDelim(state, match)
-  if (!res.canClose) {
-    if (!silent) { state.pending += '$' }
-    state.pos = start
-    return true
-  }
-
-  if (!silent) {
-    token = state.push('katex_inline', 'math', 0)
-    token.markup = '$'
-    token.content = state.src.slice(start, match)
-  }
-
-  state.pos = match + 1
-  return true
-}
-
-function katexBlock (state, start, end, silent) {
-  let firstLine; let lastLine; let next; let lastPos; let found = false; let token
-  let pos = state.bMarks[start] + state.tShift[start]
-  let max = state.eMarks[start]
-
-  if (pos + 2 > max) { return false }
-  if (state.src.slice(pos, pos + 2) !== '$$') { return false }
-
-  pos += 2
-  firstLine = state.src.slice(pos, max)
-
-  if (silent) { return true }
-  if (firstLine.trim().slice(-2) === '$$') {
-    // Single line expression
-    firstLine = firstLine.trim().slice(0, -2)
-    found = true
-  }
-
-  for (next = start; !found;) {
-    next++
-
-    if (next >= end) { break }
-
-    pos = state.bMarks[next] + state.tShift[next]
-    max = state.eMarks[next]
-
-    if (pos < max && state.tShift[next] < state.blkIndent) {
-      // non-empty line with negative indent should stop the list:
-      break
-    }
-
-    if (state.src.slice(pos, max).trim().slice(-2) === '$$') {
-      lastPos = state.src.slice(0, max).lastIndexOf('$$')
-      lastLine = state.src.slice(pos, lastPos)
-      found = true
-    }
-  }
-
-  state.line = next + 1
-
-  token = state.push('katex_block', 'math', 0)
-  token.block = true
-  token.content = (firstLine && firstLine.trim() ? firstLine + '\n' : '') +
-  state.getLines(start + 1, next, state.tShift[start], true) +
-  (lastLine && lastLine.trim() ? lastLine : '')
-  token.map = [ start, state.line ]
-  token.markup = '$$'
-  return true
 }

--- a/server/modules/rendering/markdown-mathjax/renderer.js
+++ b/server/modules/rendering/markdown-mathjax/renderer.js
@@ -1,4 +1,5 @@
 const mjax = require('mathjax')
+const latexMatcher = require('../../../helpers/latex-matcher')
 
 /* global WIKI */
 
@@ -35,7 +36,7 @@ module.exports = {
       }
     })
     if (conf.useInline) {
-      mdinst.inline.ruler.after('escape', 'mathjax_inline', mathjaxInline)
+      mdinst.inline.ruler.after('escape', 'mathjax_inline', (...args) => latexMatcher.latexInline('mathjax_inline', ...args))
       mdinst.renderer.rules.mathjax_inline = (tokens, idx) => {
         try {
           const result = MathJax.tex2svg(tokens[idx].content, {
@@ -49,7 +50,7 @@ module.exports = {
       }
     }
     if (conf.useBlocks) {
-      mdinst.block.ruler.after('blockquote', 'mathjax_block', mathjaxBlock, {
+      mdinst.block.ruler.after('blockquote', 'mathjax_block', (...args) => latexMatcher.latexBlock('mathjax_block', ...args), {
         alt: [ 'paragraph', 'reference', 'blockquote', 'list' ]
       })
       mdinst.renderer.rules.mathjax_block = (tokens, idx) => {
@@ -65,143 +66,4 @@ module.exports = {
       }
     }
   }
-}
-
-// Test if potential opening or closing delimieter
-// Assumes that there is a "$" at state.src[pos]
-function isValidDelim (state, pos) {
-  let prevChar
-  let nextChar
-  let max = state.posMax
-  let canOpen = true
-  let canClose = true
-
-  prevChar = pos > 0 ? state.src.charCodeAt(pos - 1) : -1
-  nextChar = pos + 1 <= max ? state.src.charCodeAt(pos + 1) : -1
-
-  // Check non-whitespace conditions for opening and closing, and
-  // check that closing delimeter isn't followed by a number
-  if (prevChar === 0x20/* " " */ || prevChar === 0x09/* \t */ ||
-  (nextChar >= 0x30/* "0" */ && nextChar <= 0x39/* "9" */)) {
-    canClose = false
-  }
-  if (nextChar === 0x20/* " " */ || nextChar === 0x09/* \t */) {
-    canOpen = false
-  }
-
-  return {
-    canOpen: canOpen,
-    canClose: canClose
-  }
-}
-
-function mathjaxInline (state, silent) {
-  let start, match, token, res, pos
-
-  if (state.src[state.pos] !== '$') { return false }
-
-  res = isValidDelim(state, state.pos)
-  if (!res.canOpen) {
-    if (!silent) { state.pending += '$' }
-    state.pos += 1
-    return true
-  }
-
-  // First check for and bypass all properly escaped delimieters
-  // This loop will assume that the first leading backtick can not
-  // be the first character in state.src, which is known since
-  // we have found an opening delimieter already.
-  start = state.pos + 1
-  match = start
-  while ((match = state.src.indexOf('$', match)) !== -1) {
-    // Found potential $, look for escapes, pos will point to
-    // first non escape when complete
-    pos = match - 1
-    while (state.src[pos] === '\\') { pos -= 1 }
-
-    // Even number of escapes, potential closing delimiter found
-    if (((match - pos) % 2) === 1) { break }
-    match += 1
-  }
-
-  // No closing delimter found.  Consume $ and continue.
-  if (match === -1) {
-    if (!silent) { state.pending += '$' }
-    state.pos = start
-    return true
-  }
-
-  // Check if we have empty content, ie: $$.  Do not parse.
-  if (match - start === 0) {
-    if (!silent) { state.pending += '$$' }
-    state.pos = start + 1
-    return true
-  }
-
-  // Check for valid closing delimiter
-  res = isValidDelim(state, match)
-  if (!res.canClose) {
-    if (!silent) { state.pending += '$' }
-    state.pos = start
-    return true
-  }
-
-  if (!silent) {
-    token = state.push('mathjax_inline', 'math', 0)
-    token.markup = '$'
-    token.content = state.src.slice(start, match)
-  }
-
-  state.pos = match + 1
-  return true
-}
-
-function mathjaxBlock (state, start, end, silent) {
-  let firstLine; let lastLine; let next; let lastPos; let found = false; let token
-  let pos = state.bMarks[start] + state.tShift[start]
-  let max = state.eMarks[start]
-
-  if (pos + 2 > max) { return false }
-  if (state.src.slice(pos, pos + 2) !== '$$') { return false }
-
-  pos += 2
-  firstLine = state.src.slice(pos, max)
-
-  if (silent) { return true }
-  if (firstLine.trim().slice(-2) === '$$') {
-    // Single line expression
-    firstLine = firstLine.trim().slice(0, -2)
-    found = true
-  }
-
-  for (next = start; !found;) {
-    next++
-
-    if (next >= end) { break }
-
-    pos = state.bMarks[next] + state.tShift[next]
-    max = state.eMarks[next]
-
-    if (pos < max && state.tShift[next] < state.blkIndent) {
-      // non-empty line with negative indent should stop the list:
-      break
-    }
-
-    if (state.src.slice(pos, max).trim().slice(-2) === '$$') {
-      lastPos = state.src.slice(0, max).lastIndexOf('$$')
-      lastLine = state.src.slice(pos, lastPos)
-      found = true
-    }
-  }
-
-  state.line = next + 1
-
-  token = state.push('mathjax_block', 'math', 0)
-  token.block = true
-  token.content = (firstLine && firstLine.trim() ? firstLine + '\n' : '') +
-  state.getLines(start + 1, next, state.tShift[start], true) +
-  (lastLine && lastLine.trim() ? lastLine : '')
-  token.map = [ start, state.line ]
-  token.markup = '$$'
-  return true
 }


### PR DESCRIPTION
- In VNOI Wiki, we don't have non-whitespace condition, so the `isValidDelim` will always return true
- Also i refactor the latex matcher so we don't have duplication in both katex and mathjax
- TODO: Frontend to use the same matcher file