### PR TITLE
Add toggle site theme button

### DIFF
--- a/client/client-app.js
+++ b/client/client-app.js
@@ -193,8 +193,13 @@ let bootstrap = () => {
   const i18n = localization.init()
 
   let darkModeEnabled = siteConfig.darkMode
-  if ((store.get('user/appearance') || '').length > 0) {
-    darkModeEnabled = (store.get('user/appearance') === 'dark')
+  const localTheme = localStorage.getItem('theme')
+  const userAppearance = store.get('user/appearance') || ''
+
+  if (userAppearance.length > 0) {
+    darkModeEnabled = (userAppearance === 'dark')
+  } else if (localTheme) {
+    darkModeEnabled = (localTheme === 'dark')
   }
 
   window.WIKI = new Vue({

--- a/client/components/common/nav-header.vue
+++ b/client/components/common/nav-header.vue
@@ -188,6 +188,15 @@
               span {{$t('common:actions.exit')}}
             v-divider(vertical)
 
+          //- THEME TOGGLE
+
+          v-tooltip(bottom)
+            template(v-slot:activator='{ on }')
+              v-btn(icon, tile, height='64', v-on='on', @click='toggleTheme', :aria-label='$t(`common:header.toggleTheme`)')
+                v-icon(color='grey') {{ $vuetify.theme.dark ? 'mdi-white-balance-sunny' : 'mdi-weather-night' }}
+            span {{ $vuetify.theme.dark ? $t('common:header.lightMode') : $t('common:header.darkMode') }}
+          v-divider(vertical)
+
           //- ACCOUNT
 
           v-menu(v-if='isAuthenticated', offset-y, bottom, min-width='300', transition='slide-y-transition', left)
@@ -477,6 +486,12 @@ export default {
     },
     goHome () {
       window.location.assign('/')
+    },
+    toggleTheme () {
+      this.$vuetify.theme.dark = !this.$vuetify.theme.dark
+
+      const newTheme = this.$vuetify.theme.dark ? 'dark' : 'light'
+      localStorage.setItem('theme', newTheme)
     }
   }
 }


### PR DESCRIPTION
Apparently, Wiki.js has theme settings, but only logged-in users are able to set them. 

This change allows users to quickly change the theme.
<img width="412" height="371" alt="image" src="https://github.com/user-attachments/assets/747f0cdb-e30d-4a0e-ac53-3783569274d5" />
