### PR TITLE
Fix list inside a spoiler got push out side of container

### DIFF
--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -504,7 +504,6 @@
 
   ol, ul:not(.tabset-tabs) {
     padding-top: 1rem;
-    width: 100%;
 
     @at-root .is-rtl & {
       padding-left: 0;


### PR DESCRIPTION
Before
<img width="972" height="450" alt="image" src="https://github.com/user-attachments/assets/90b5d2f8-1b64-44a8-8ce3-e44a97e7df4a" />

After 
<img width="1012" height="480" alt="image" src="https://github.com/user-attachments/assets/63cf1632-79ae-47da-82a9-6366327ade8f" />

